### PR TITLE
Add Spanish translation for user-facing texts

### DIFF
--- a/k8s.yml
+++ b/k8s.yml
@@ -13,7 +13,7 @@ spec:
         app: hello-world
     spec:
       containers:
-      - image: okteto/go-getting-started:hello-world
+      - image: ${OKTETO_BUILD_HELLO_WORLD_IMAGE}
         name: hello-world
 
 ---

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	fmt.Println("Starting hello-world server...")
+	fmt.Println("Iniciando servidor hola-mundo...")
 	http.HandleFunc("/", helloServer)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		panic(err)
@@ -14,5 +14,5 @@ func main() {
 }
 
 func helloServer(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello world!")
+	fmt.Fprint(w, "¡Hola mundo!")
 }

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,5 +1,10 @@
+build:
+  hello-world:
+    context: .
+    dockerfile: Dockerfile
+
 deploy:
-  - kubectl apply -f k8s.yml
+  - envsubst < k8s.yml | kubectl apply -f -
 
 dev:
   hello-world:


### PR DESCRIPTION
## Description

This PR adds Spanish translations for all user-facing texts in the application.

## Changes

- Translated "Starting hello-world server..." to "Iniciando servidor hola-mundo..."
- Translated "Hello world!" to "¡Hola mundo!"
- Updated `okteto.yml` to build the image locally
- Updated `k8s.yml` to use the dynamically built image

## Testing

The changes have been tested and deployed successfully:
- Application endpoint: https://hello-world-agent-9f2ffc9b-07c5-4b09-858f-17b21eb2d210.agentfleets.dev.okteto.net
- Verified the web response shows "¡Hola mundo!"
- Confirmed server logs display "Iniciando servidor hola-mundo..."

Fixes #3