### PR TITLE
Spanish Translation - Issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Getting Started on Okteto with Go
+# Comenzando con Okteto y Go
 
-This example shows how to use the [Okteto CLI](https://github.com/okteto/okteto) to develop a Go Sample App directly in Kubernetes. The Go Sample App is deployed using Kubernetes manifests.
+Este ejemplo muestra cómo usar el [CLI de Okteto](https://github.com/okteto/okteto) para desarrollar una aplicación de ejemplo en Go directamente en Kubernetes. La aplicación de ejemplo en Go se despliega usando manifiestos de Kubernetes.
 
-This is the application used for the [Getting Started on Okteto with Go](https://www.okteto.com/docs/samples/golang/) tutorial.
+Esta es la aplicación utilizada para el tutorial [Comenzando con Okteto y Go](https://www.okteto.com/docs/samples/golang/).

--- a/k8s.yml
+++ b/k8s.yml
@@ -13,7 +13,7 @@ spec:
         app: hello-world
     spec:
       containers:
-      - image: okteto/go-getting-started:hello-world
+      - image: ${OKTETO_BUILD_HELLO_WORLD_IMAGE}
         name: hello-world
 
 ---

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	fmt.Println("Starting hello-world server...")
+	fmt.Println("Iniciando servidor hola-mundo...")
 	http.HandleFunc("/", helloServer)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		panic(err)
@@ -14,5 +14,5 @@ func main() {
 }
 
 func helloServer(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello world!")
+	fmt.Fprint(w, "¡Hola mundo!")
 }

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,5 +1,10 @@
+build:
+  hello-world:
+    context: .
+    dockerfile: Dockerfile
+
 deploy:
-  - kubectl apply -f k8s.yml
+  - envsubst < k8s.yml | kubectl apply -f -
 
 dev:
   hello-world:


### PR DESCRIPTION
## Description

This PR implements Spanish translation for all user-facing text in the application as requested in issue #5.

## Changes Made

### Application Code (main.go)
- Translated "Hello world!" to "¡Hola mundo!"
- Translated "Starting hello-world server..." to "Iniciando servidor hola-mundo..."

### Documentation (README.md)
- Translated the entire README content to Spanish
- Title: "Getting Started on Okteto with Go" → "Comenzando con Okteto y Go"
- Description and tutorial reference also translated

### Infrastructure Updates
- Updated `okteto.yml` to build the image locally with the translations
- Modified `k8s.yml` to use the environment variable for the built image

## Testing

The application has been successfully deployed and tested on Okteto:
- Web endpoint returns: `¡Hola mundo!`
- Console logs show: `Iniciando servidor hola-mundo...`
- Endpoint: https://hello-world-agent-eac760a6-d4b1-4607-9be2-3339779b4bd0.agentfleets.dev.okteto.net

## Fixes

Fixes #5